### PR TITLE
CI: add Python 3.14 support, drop win32 wheels

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -105,6 +105,9 @@ jobs:
           # Always skip free-threaded builds (testing infrastructure not yet in place).
           # On PR: also skip cp38 musllinux builds (they take ~6 minutes).
           CIBW_SKIP: ${{ github.event_name == 'pull_request' && 'cp*t-* cp38-musllinux*' || 'cp*t-*' }}
+          # Only build 64-bit Windows wheels.  scipy and matplotlib have dropped
+          # win32 support, making 32-bit wheels untestable in CI.
+          CIBW_ARCHS_WINDOWS: AMD64
 
       - name: Generate build provenance attestations for wheels
         # Only generate attestations for trusted workflows (not fork PRs)

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -73,7 +73,10 @@ jobs:
 
       - name: Set up OpenMP for macOS
         if: runner.os == 'macOS'
+        shell: bash
         run: |
+          set -euxo pipefail
+
           # Use a conda-forge libomp built against an old macOS SDK so that
           # delocate can bundle it into wheels targeting 10.9 (x86_64) or
           # 11.0 (arm64).  Homebrew's libomp targets the runner's OS, which
@@ -87,7 +90,9 @@ jobs:
 
           PREFIX="$HOME/openmp"
           mkdir -p "$PREFIX"
-          curl -sL "$OPENMP_URL" | tar xj -C "$PREFIX"
+          curl --fail --retry 3 -sL "$OPENMP_URL" | tar xj -C "$PREFIX"
+
+          ls "$PREFIX/lib/libomp.dylib"
 
           echo "CC=/usr/bin/clang"    >> $GITHUB_ENV
           echo "CXX=/usr/bin/clang++" >> $GITHUB_ENV

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -99,9 +99,9 @@ jobs:
       - name: Build wheels with cibuildwheel
         uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
         env:
-          # On PR: only build extremal Python versions (3.8 and 3.13)
+          # On PR: only build extremal Python versions (3.8 and 3.14)
           # On main/release: build all supported versions (default behavior)
-          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp38-* cp313-*' || '' }}
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp38-* cp314-*' || '' }}
           # Always skip free-threaded builds (testing infrastructure not yet in place).
           # On PR: also skip cp38 musllinux builds (they take ~6 minutes).
           CIBW_SKIP: ${{ github.event_name == 'pull_request' && 'cp*t-* cp38-musllinux*' || 'cp*t-*' }}

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -102,8 +102,9 @@ jobs:
           # On PR: only build extremal Python versions (3.8 and 3.13)
           # On main/release: build all supported versions (default behavior)
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp38-* cp313-*' || '' }}
-          # On PR: skip cp38 musllinux builds (they take ~6 minutes)
-          CIBW_SKIP: ${{ github.event_name == 'pull_request' && 'cp38-musllinux*' || '' }}
+          # Always skip free-threaded builds (testing infrastructure not yet in place).
+          # On PR: also skip cp38 musllinux builds (they take ~6 minutes).
+          CIBW_SKIP: ${{ github.event_name == 'pull_request' && 'cp*t-* cp38-musllinux*' || 'cp*t-*' }}
 
       - name: Generate build provenance attestations for wheels
         # Only generate attestations for trusted workflows (not fork PRs)
@@ -190,6 +191,7 @@ jobs:
             3.11
             3.12
             3.13
+            3.14
 
       - name: Install script dependencies
         shell: bash

--- a/cibuildwheel-scripts/generate_test_matrix.py
+++ b/cibuildwheel-scripts/generate_test_matrix.py
@@ -36,14 +36,6 @@ include:
     python-filter: ""
     run-on-pr: true
 
-  - os: windows-latest
-    platform: windows-x86
-    python-cmd: python
-    setup-python: true
-    setup-python-arch: x86
-    python-filter: "win32"
-    run-on-pr: false
-
   - os: macos-15-intel
     platform: macos-15-intel
     python-cmd: python


### PR DESCRIPTION
## Summary

- **Add Python 3.14 to the build and test matrix.** `cibuildwheel` now builds cp314 wheels on all platforms, `setup-python` provisions 3.14 for testing, and the PR filter exercises `cp38` + `cp314` as the extremal versions.
- **Skip free-threaded (cp314t) builds.** Neither scipy nor matplotlib ship stable free-threaded wheels yet, so `cp*t-*` is added to `CIBW_SKIP` to avoid untestable artifacts.
- **Stop building 32-bit Windows wheels.** scipy and matplotlib have dropped win32 support, making these wheels impossible to test in CI. `CIBW_ARCHS_WINDOWS: AMD64` restricts builds to 64-bit, and the `windows-x86` test matrix entry is removed.

Made with [Cursor](https://cursor.com)